### PR TITLE
Update AGP from 8.5.1 to 8.7.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.1"
+agp = "8.7.3"
 kotlin = "2.0.0"
 kotlinJvm = "2.0.0"
 core-ktx = "1.13.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Feb 11 10:03:22 IRST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary by Sourcery

Upgrade Android Gradle Plugin (AGP) from 8.5.1 to 8.7.3 and Gradle from 8.7 to 8.9.

Build:
- Update AGP to 8.7.3.
- Update Gradle to 8.9.